### PR TITLE
Implement SwiftUI UI, move history and en passant

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,16 @@
+name: Swift CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: '6.1'
+      - run: swift test --enable-test-discovery

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing to Casa Ajedrez
+
+Thank you for your interest in contributing! To submit code:
+
+1. Fork the repository and create a feature branch.
+2. Make your changes and ensure `swift test` passes.
+3. Open a pull request describing your changes.
+
+Please include tests for new features when possible.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Casa Ajedrez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "CasaAjedrez",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "CasaAjedrez",
+            targets: ["CasaAjedrez"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "CasaAjedrez"),
+        .testTarget(
+            name: "CasaAjedrezTests",
+            dependencies: ["CasaAjedrez"]
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# CasaAjedrez
+# Casa Ajedrez
+
+Casa Ajedrez is an open-source iOS chess app built with Swift and SwiftUI. It features comprehensive piece logic and rule validation along with an AI opponent powered by the Minimax algorithm. The project emphasizes accurate game state handling, smooth animations, and clean board rendering.
+
+## Features
+
+- Full chess rules and piece movement, including castling, en passant and pawn promotion
+- Minimax-based AI opponent
+- SwiftUI interface with animations and touch interaction
+- Move history with undo/redo
+
+## Project Tasks
+
+The following list outlines the major tasks planned for the project:
+
+1. **Project setup** – create a Swift Package Manager project and configure Git.
+2. **Chess game logic** – implement piece models and movement rules.
+3. **AI opponent** – add a Minimax-based algorithm for the computer player.
+4. **SwiftUI interface** – build a responsive chessboard UI with animations.
+5. **Game state management** – track moves, turns and game status.
+6. **Testing** – write unit tests for move validation and AI logic.
+7. **Documentation** – keep this README and source comments up to date.
+8. **Open-source compliance** – provide a license and contribution guidelines.
+
+## Repository Status
+
+The repository now provides a working chess engine with check detection,
+castling and pawn promotion, plus a Minimax AI. A GitHub Actions workflow
+runs the test suite on each pull request.
+
+## Building
+
+Ensure you have Swift 6.1 or later installed. To build the package:
+
+```bash
+swift build
+```
+
+### Running Tests
+
+Execute the test suite with:
+
+```bash
+swift test
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details on contributing to this project.
+
+## License
+
+This project is released under the MIT License. See [LICENSE](LICENSE) for
+details.
+

--- a/Sources/CasaAjedrez/Board.swift
+++ b/Sources/CasaAjedrez/Board.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+public enum PieceColor {
+    case white
+    case black
+}
+
+public enum PieceType {
+    case king, queen, rook, bishop, knight, pawn
+}
+
+public struct Piece {
+    public let type: PieceType
+    public let color: PieceColor
+
+    public init(_ type: PieceType, _ color: PieceColor) {
+        self.type = type
+        self.color = color
+    }
+}
+
+public struct Board {
+    // 8x8 board indexed by file and rank
+    private(set) var squares: [[Piece?]]
+
+    public init() {
+        squares = Array(repeating: Array(repeating: nil, count: 8), count: 8)
+        setupInitialPosition()
+    }
+
+    public init(empty: Bool) {
+        squares = Array(repeating: Array(repeating: nil, count: 8), count: 8)
+        if !empty {
+            setupInitialPosition()
+        }
+    }
+
+    mutating func setupInitialPosition() {
+        // Place pawns
+        for file in 0..<8 {
+            squares[1][file] = Piece(.pawn, .white)
+            squares[6][file] = Piece(.pawn, .black)
+        }
+        // Place major pieces
+        let backRank: [PieceType] = [.rook, .knight, .bishop, .queen,
+                                     .king, .bishop, .knight, .rook]
+        for file in 0..<8 {
+            squares[0][file] = Piece(backRank[file], .white)
+            squares[7][file] = Piece(backRank[file], .black)
+        }
+    }
+
+    private func clearVertical(from: (Int, Int), to: (Int, Int)) -> Bool {
+        let (start, end) = from.0 < to.0 ? (from.0 + 1, to.0) : (to.0 + 1, from.0)
+        for r in start..<end { if squares[r][from.1] != nil { return false } }
+        return true
+    }
+
+    private func clearHorizontal(from: (Int, Int), to: (Int, Int)) -> Bool {
+        let (start, end) = from.1 < to.1 ? (from.1 + 1, to.1) : (to.1 + 1, from.1)
+        for f in start..<end { if squares[from.0][f] != nil { return false } }
+        return true
+    }
+
+    private func clearDiagonal(from: (Int, Int), to: (Int, Int)) -> Bool {
+        let rankStep = from.0 < to.0 ? 1 : -1
+        let fileStep = from.1 < to.1 ? 1 : -1
+        var r = from.0 + rankStep
+        var f = from.1 + fileStep
+        while r != to.0 && f != to.1 {
+            if squares[r][f] != nil { return false }
+            r += rankStep
+            f += fileStep
+        }
+        return true
+    }
+
+    public func isValidMove(for piece: Piece, from: (Int, Int), to: (Int, Int), enPassant: (Int, Int)? = nil) -> Bool {
+        guard (0..<8).contains(to.0), (0..<8).contains(to.1) else { return false }
+        if let dest = self[to.0, to.1], dest.color == piece.color { return false }
+
+        switch piece.type {
+        case .pawn:
+            let direction = piece.color == .white ? 1 : -1
+            let startRank = piece.color == .white ? 1 : 6
+            if from.1 == to.1 {
+                if to.0 - from.0 == direction && self[to.0, to.1] == nil { return true }
+                if from.0 == startRank && to.0 - from.0 == 2 * direction {
+                    let intermediate = from.0 + direction
+                    if self[intermediate, from.1] == nil && self[to.0, to.1] == nil { return true }
+                }
+            } else if to.0 - from.0 == direction && abs(to.1 - from.1) == 1 {
+                if let dest = self[to.0, to.1], dest.color != piece.color { return true }
+                if let ep = enPassant, ep == to, self[from.0, to.1]?.type == .pawn { return true }
+            }
+            return false
+        case .rook:
+            if from.0 == to.0 { return clearHorizontal(from: from, to: to) }
+            if from.1 == to.1 { return clearVertical(from: from, to: to) }
+            return false
+        case .knight:
+            let dr = abs(to.0 - from.0)
+            let df = abs(to.1 - from.1)
+            return (dr == 2 && df == 1) || (dr == 1 && df == 2)
+        case .bishop:
+            if abs(to.0 - from.0) == abs(to.1 - from.1) {
+                return clearDiagonal(from: from, to: to)
+            }
+            return false
+        case .queen:
+            if from.0 == to.0 { return clearHorizontal(from: from, to: to) }
+            if from.1 == to.1 { return clearVertical(from: from, to: to) }
+            if abs(to.0 - from.0) == abs(to.1 - from.1) {
+                return clearDiagonal(from: from, to: to)
+            }
+            return false
+        case .king:
+            return max(abs(to.0 - from.0), abs(to.1 - from.1)) == 1
+        }
+    }
+
+    func kingPosition(for color: PieceColor) -> (Int, Int)? {
+        for r in 0..<8 {
+            for f in 0..<8 {
+                if let p = squares[r][f], p.type == .king && p.color == color {
+                    return (r, f)
+                }
+            }
+        }
+        return nil
+    }
+
+    func isSquareAttacked(_ square: (Int, Int), by color: PieceColor) -> Bool {
+        for r in 0..<8 {
+            for f in 0..<8 {
+                if let piece = squares[r][f], piece.color == color {
+                    if isValidMove(for: piece, from: (r, f), to: square, enPassant: nil) {
+                        return true
+                    }
+                }
+            }
+        }
+        return false
+    }
+
+    func isKingInCheck(_ color: PieceColor) -> Bool {
+        guard let kingPos = kingPosition(for: color) else { return false }
+        let opponent: PieceColor = color == .white ? .black : .white
+        return isSquareAttacked(kingPos, by: opponent)
+    }
+
+    func generateMoves(for color: PieceColor, enPassant: (Int, Int)? = nil) -> [((Int, Int), (Int, Int))] {
+        var moves: [((Int, Int), (Int, Int))] = []
+        for r in 0..<8 {
+            for f in 0..<8 {
+                guard let piece = squares[r][f], piece.color == color else { continue }
+                for r2 in 0..<8 {
+                    for f2 in 0..<8 {
+                        if isValidMove(for: piece, from: (r, f), to: (r2, f2), enPassant: enPassant) {
+                            var copy = self
+                            copy[r2, f2] = piece
+                            copy[r, f] = nil
+                            if !copy.isKingInCheck(color) {
+                                moves.append(((r, f), (r2, f2)))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return moves
+    }
+
+    public subscript(rank: Int, file: Int) -> Piece? {
+        get { squares[rank][file] }
+        set { squares[rank][file] = newValue }
+    }
+}

--- a/Sources/CasaAjedrez/Game.swift
+++ b/Sources/CasaAjedrez/Game.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+public enum GameError: Error {
+    case invalidMove
+}
+
+struct CastlingRights {
+    var whiteKingside = true
+    var whiteQueenside = true
+    var blackKingside = true
+    var blackQueenside = true
+}
+
+public struct Game {
+    private struct GameState {
+        var board: Board
+        var currentTurn: PieceColor
+        var castlingRights: CastlingRights
+        var enPassantSquare: (Int, Int)?
+    }
+
+    public private(set) var board: Board
+    public private(set) var currentTurn: PieceColor
+    private var castlingRights = CastlingRights()
+    private var enPassantSquare: (Int, Int)? = nil
+    private var history: [GameState] = []
+    private var redoStack: [GameState] = []
+
+    public init() {
+        self.board = Board()
+        self.currentTurn = .white
+        self.castlingRights = CastlingRights()
+    }
+
+    public init(board: Board, currentTurn: PieceColor = .white) {
+        self.board = board
+        self.currentTurn = currentTurn
+        self.castlingRights = CastlingRights()
+    }
+
+    public mutating func applyMove(from: (Int, Int), to: (Int, Int)) throws {
+        guard let piece = board[from.0, from.1], piece.color == currentTurn else {
+            throw GameError.invalidMove
+        }
+        history.append(GameState(board: board, currentTurn: currentTurn, castlingRights: castlingRights, enPassantSquare: enPassantSquare))
+        redoStack.removeAll()
+
+        var captured = board[to.0, to.1]
+
+        if board.isValidMove(for: piece, from: from, to: to, enPassant: enPassantSquare) {
+            var copy = board
+            copy[from.0, from.1] = nil
+            var movedPiece = piece
+
+            if piece.type == .pawn, let ep = enPassantSquare, ep == to, captured == nil {
+                let capPos = (from.0, to.1)
+                captured = board[capPos.0, capPos.1]
+                copy[capPos.0, capPos.1] = nil
+            }
+
+            if piece.type == .pawn && (to.0 == 7 || to.0 == 0) {
+                movedPiece = Piece(.queen, piece.color)
+            }
+
+            copy[to.0, to.1] = movedPiece
+
+            if copy.isKingInCheck(currentTurn) {
+                throw GameError.invalidMove
+            }
+
+            board = copy
+        } else if piece.type == .king && from.1 == 4 && (to.1 == 6 || to.1 == 2) {
+            try castle(from: from, to: to, color: piece.color)
+            captured = nil
+        } else {
+            history.removeLast()
+            throw GameError.invalidMove
+        }
+
+        if piece.type == .pawn && abs(to.0 - from.0) == 2 {
+            let direction = piece.color == .white ? 1 : -1
+            enPassantSquare = (from.0 + direction, from.1)
+        } else {
+            enPassantSquare = nil
+        }
+
+        updateCastlingRights(piece: piece, from: from, to: to, captured: captured)
+        currentTurn = currentTurn == .white ? .black : .white
+    }
+
+    public func isCheck(for color: PieceColor) -> Bool {
+        board.isKingInCheck(color)
+    }
+
+    public func isCheckmate(for color: PieceColor) -> Bool {
+        board.isKingInCheck(color) && board.generateMoves(for: color, enPassant: enPassantSquare).isEmpty
+    }
+
+    public func isStalemate(for color: PieceColor) -> Bool {
+        !board.isKingInCheck(color) && board.generateMoves(for: color, enPassant: enPassantSquare).isEmpty
+    }
+
+    private func canCastleKingside(color: PieceColor) -> Bool {
+        let rank = color == .white ? 0 : 7
+        let opponent: PieceColor = color == .white ? .black : .white
+        if color == .white && !castlingRights.whiteKingside { return false }
+        if color == .black && !castlingRights.blackKingside { return false }
+        guard board[rank, 4]?.type == .king, board[rank, 7]?.type == .rook else {
+            return false
+        }
+        if board[rank,5] != nil || board[rank,6] != nil { return false }
+        if board.isSquareAttacked((rank,4), by: opponent) ||
+            board.isSquareAttacked((rank,5), by: opponent) ||
+            board.isSquareAttacked((rank,6), by: opponent) { return false }
+        return true
+    }
+
+    private func canCastleQueenside(color: PieceColor) -> Bool {
+        let rank = color == .white ? 0 : 7
+        let opponent: PieceColor = color == .white ? .black : .white
+        if color == .white && !castlingRights.whiteQueenside { return false }
+        if color == .black && !castlingRights.blackQueenside { return false }
+        guard board[rank, 4]?.type == .king, board[rank, 0]?.type == .rook else {
+            return false
+        }
+        if board[rank,1] != nil || board[rank,2] != nil || board[rank,3] != nil { return false }
+        if board.isSquareAttacked((rank,4), by: opponent) ||
+            board.isSquareAttacked((rank,3), by: opponent) ||
+            board.isSquareAttacked((rank,2), by: opponent) { return false }
+        return true
+    }
+
+    private mutating func castle(from: (Int, Int), to: (Int, Int), color: PieceColor) throws {
+        let rank = color == .white ? 0 : 7
+        if to.1 == 6 {
+            guard canCastleKingside(color: color) else { throw GameError.invalidMove }
+            board[rank,4] = nil
+            board[rank,6] = Piece(.king, color)
+            board[rank,7] = nil
+            board[rank,5] = Piece(.rook, color)
+        } else {
+            guard canCastleQueenside(color: color) else { throw GameError.invalidMove }
+            board[rank,4] = nil
+            board[rank,2] = Piece(.king, color)
+            board[rank,0] = nil
+            board[rank,3] = Piece(.rook, color)
+        }
+    }
+
+    private mutating func updateCastlingRights(piece: Piece, from: (Int, Int), to: (Int, Int), captured: Piece?) {
+        switch piece.type {
+        case .king:
+            if piece.color == .white {
+                castlingRights.whiteKingside = false
+                castlingRights.whiteQueenside = false
+            } else {
+                castlingRights.blackKingside = false
+                castlingRights.blackQueenside = false
+            }
+        case .rook:
+            if piece.color == .white {
+                if from == (0,0) { castlingRights.whiteQueenside = false }
+                if from == (0,7) { castlingRights.whiteKingside = false }
+            } else {
+                if from == (7,0) { castlingRights.blackQueenside = false }
+                if from == (7,7) { castlingRights.blackKingside = false }
+            }
+        default: break
+        }
+
+        if let cap = captured, cap.type == .rook {
+            if cap.color == .white {
+                if to == (0,0) { castlingRights.whiteQueenside = false }
+                if to == (0,7) { castlingRights.whiteKingside = false }
+            } else {
+                if to == (7,0) { castlingRights.blackQueenside = false }
+                if to == (7,7) { castlingRights.blackKingside = false }
+            }
+        }
+    }
+
+    public mutating func undo() {
+        guard let last = history.popLast() else { return }
+        redoStack.append(GameState(board: board, currentTurn: currentTurn, castlingRights: castlingRights, enPassantSquare: enPassantSquare))
+        board = last.board
+        currentTurn = last.currentTurn
+        castlingRights = last.castlingRights
+        enPassantSquare = last.enPassantSquare
+    }
+
+    public mutating func redo() {
+        guard let next = redoStack.popLast() else { return }
+        history.append(GameState(board: board, currentTurn: currentTurn, castlingRights: castlingRights, enPassantSquare: enPassantSquare))
+        board = next.board
+        currentTurn = next.currentTurn
+        castlingRights = next.castlingRights
+        enPassantSquare = next.enPassantSquare
+    }
+}

--- a/Sources/CasaAjedrez/MinimaxAI.swift
+++ b/Sources/CasaAjedrez/MinimaxAI.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+public struct MinimaxAI {
+    public init() {}
+
+    func evaluate(_ board: Board, for color: PieceColor) -> Int {
+        var score = 0
+        for r in 0..<8 {
+            for f in 0..<8 {
+                guard let piece = board[r, f] else { continue }
+                let value: Int
+                switch piece.type {
+                case .pawn: value = 1
+                case .knight, .bishop: value = 3
+                case .rook: value = 5
+                case .queen: value = 9
+                case .king: value = 100
+                }
+                score += piece.color == color ? value : -value
+            }
+        }
+        return score
+    }
+
+    func minimax(board: Board, depth: Int, maximizing: Bool, color: PieceColor, alpha: inout Int, beta: inout Int) -> (score: Int, move: ((Int, Int), (Int, Int))?) {
+        if depth == 0 {
+            return (evaluate(board, for: color), nil)
+        }
+
+        let currentColor: PieceColor = maximizing ? color : (color == .white ? .black : .white)
+        let moves = board.generateMoves(for: currentColor)
+        if moves.isEmpty {
+            if board.isKingInCheck(currentColor) {
+                return maximizing ? (-1000, nil) : (1000, nil)
+            } else {
+                return (0, nil)
+            }
+        }
+
+        var bestMove: ((Int, Int), (Int, Int))? = nil
+
+        if maximizing {
+            var bestScore = Int.min
+            for m in moves {
+                var copy = board
+                let piece = copy[m.0.0, m.0.1]!
+                copy[m.0.0, m.0.1] = nil
+                copy[m.1.0, m.1.1] = piece
+                var a = alpha
+                var b = beta
+                let result = minimax(board: copy, depth: depth - 1, maximizing: false, color: color, alpha: &a, beta: &b)
+                if result.score > bestScore {
+                    bestScore = result.score
+                    bestMove = m
+                }
+                alpha = max(alpha, bestScore)
+                if beta <= alpha { break }
+            }
+            return (bestScore, bestMove)
+        } else {
+            var bestScore = Int.max
+            for m in moves {
+                var copy = board
+                let piece = copy[m.0.0, m.0.1]!
+                copy[m.0.0, m.0.1] = nil
+                copy[m.1.0, m.1.1] = piece
+                var a = alpha
+                var b = beta
+                let result = minimax(board: copy, depth: depth - 1, maximizing: true, color: color, alpha: &a, beta: &b)
+                if result.score < bestScore {
+                    bestScore = result.score
+                    bestMove = m
+                }
+                beta = min(beta, bestScore)
+                if beta <= alpha { break }
+            }
+            return (bestScore, bestMove)
+        }
+    }
+
+    public func chooseMove(from board: Board, for color: PieceColor = .white, depth: Int = 2) -> (from: (Int, Int), to: (Int, Int))? {
+        var alpha = Int.min
+        var beta = Int.max
+        let result = minimax(board: board, depth: depth, maximizing: true, color: color, alpha: &alpha, beta: &beta)
+        return result.move
+    }
+}

--- a/Sources/CasaAjedrez/SwiftUIBoard.swift
+++ b/Sources/CasaAjedrez/SwiftUIBoard.swift
@@ -1,0 +1,79 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+public class GameViewModel: ObservableObject {
+    @Published public private(set) var game: Game
+    @Published public var selected: (Int, Int)? = nil
+
+    public init(game: Game = Game()) {
+        self.game = game
+    }
+
+    public func tapSquare(rank: Int, file: Int) {
+        if let sel = selected {
+            do {
+                try game.applyMove(from: sel, to: (rank, file))
+                withAnimation { self.game = game }
+            } catch {
+                // ignore invalid
+            }
+            selected = nil
+        } else {
+            if let piece = game.board[rank, file], piece.color == game.currentTurn {
+                selected = (rank, file)
+            }
+        }
+    }
+
+    public func undo() { game.undo() }
+    public func redo() { game.redo() }
+}
+
+public struct BoardView: View {
+    @ObservedObject var viewModel: GameViewModel
+
+    public init(viewModel: GameViewModel) { self.viewModel = viewModel }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            ForEach((0..<8).reversed(), id: \.self) { rank in
+                HStack(spacing: 0) {
+                    ForEach(0..<8, id: \.self) { file in
+                        SquareView(piece: viewModel.game.board[rank, file])
+                            .background((rank + file) % 2 == 0 ? Color(.systemGray6) : Color(.systemGreen))
+                            .onTapGesture { viewModel.tapSquare(rank: rank, file: file) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct SquareView: View {
+    let piece: Piece?
+    var body: some View {
+        Text(symbol(for: piece))
+            .font(.system(size: 32))
+            .frame(width: 44, height: 44)
+    }
+
+    func symbol(for piece: Piece?) -> String {
+        guard let piece = piece else { return "" }
+        switch (piece.type, piece.color) {
+        case (.king, .white): return "\u{2654}"
+        case (.queen, .white): return "\u{2655}"
+        case (.rook, .white): return "\u{2656}"
+        case (.bishop, .white): return "\u{2657}"
+        case (.knight, .white): return "\u{2658}"
+        case (.pawn, .white): return "\u{2659}"
+        case (.king, .black): return "\u{265A}"
+        case (.queen, .black): return "\u{265B}"
+        case (.rook, .black): return "\u{265C}"
+        case (.bishop, .black): return "\u{265D}"
+        case (.knight, .black): return "\u{265E}"
+        case (.pawn, .black): return "\u{265F}"
+        }
+    }
+}
+#endif
+

--- a/Tests/CasaAjedrezTests/CasaAjedrezTests.swift
+++ b/Tests/CasaAjedrezTests/CasaAjedrezTests.swift
@@ -1,0 +1,125 @@
+import Testing
+@testable import CasaAjedrez
+
+@Test func boardSetup() async throws {
+    let game = Game()
+    // White pawn at starting rank
+    #expect(game.board[1, 0]?.type == .pawn)
+    #expect(game.board[1, 0]?.color == .white)
+    // Black pawn at opposite side
+    #expect(game.board[6, 0]?.color == .black)
+    // Major pieces
+    #expect(game.board[0, 0]?.type == .rook)
+    #expect(game.board[0, 1]?.type == .knight)
+    #expect(game.board[0, 3]?.type == .queen)
+}
+
+@Test func aiMove() async throws {
+    let game = Game()
+    let ai = MinimaxAI()
+    let move = ai.chooseMove(from: game.board)
+    #expect(move != nil)
+    if let m = move {
+        let piece = game.board[m.from.0, m.from.1]!
+        #expect(game.board.isValidMove(for: piece, from: m.from, to: m.to))
+    }
+}
+
+@Test func invalidMove() async throws {
+    var game = Game()
+    do {
+        try game.applyMove(from: (0, 0), to: (1, 1))
+        #expect(Bool(false)) // should not reach
+    } catch {
+        #expect(error is GameError)
+    }
+    #expect(game.board[0, 0]?.type == .rook)
+    #expect(game.board[1, 1]?.type == .pawn)
+}
+
+@Test func pawnCapture() async throws {
+    var game = Game()
+    try game.applyMove(from: (1, 0), to: (3, 0))
+    try game.applyMove(from: (6, 1), to: (4, 1))
+    try game.applyMove(from: (3, 0), to: (4, 1))
+    #expect(game.board[4, 1]?.color == .white)
+    #expect(game.board[4, 1]?.type == .pawn)
+}
+
+@Test func knightMove() async throws {
+    var game = Game()
+    try game.applyMove(from: (0, 1), to: (2, 2))
+    #expect(game.board[2, 2]?.type == .knight)
+}
+
+@Test func bishopMove() async throws {
+    var board = Board()
+    board[1, 3] = nil // clear pawn in front of bishop
+    let bishop = board[0, 2]!
+    #expect(board.isValidMove(for: bishop, from: (0, 2), to: (3, 5)))
+}
+
+@Test func checkDetection() async throws {
+    var board = Board(empty: true)
+    board[0, 4] = Piece(.king, .white)
+    board[7, 4] = Piece(.king, .black)
+    board[1, 4] = Piece(.rook, .white)
+    #expect(board.isKingInCheck(.black))
+}
+
+@Test func checkmateDetection() async throws {
+    var board = Board(empty: true)
+    board[0, 0] = Piece(.king, .white)
+    board[7, 7] = Piece(.king, .black)
+    board[1, 0] = Piece(.rook, .black)
+    board[0, 1] = Piece(.rook, .black)
+    board[1, 1] = Piece(.queen, .black)
+    let game = Game(board: board)
+    #expect(game.isCheckmate(for: .white))
+}
+
+@Test func castlingMove() async throws {
+    var board = Board(empty: true)
+    board[0, 4] = Piece(.king, .white)
+    board[0, 7] = Piece(.rook, .white)
+    board[7, 4] = Piece(.king, .black)
+    let game = Game(board: board)
+    var g = game
+    try g.applyMove(from: (0,4), to: (0,6))
+    #expect(g.board[0,6]?.type == .king)
+    #expect(g.board[0,5]?.type == .rook)
+}
+
+@Test func pawnPromotion() async throws {
+    var board = Board(empty: true)
+    board[6, 0] = Piece(.pawn, .white)
+    board[0, 4] = Piece(.king, .white)
+    board[7, 4] = Piece(.king, .black)
+    var game = Game(board: board)
+    try game.applyMove(from: (6,0), to: (7,0))
+    #expect(game.board[7,0]?.type == .queen)
+    #expect(game.board[7,0]?.color == .white)
+}
+
+@Test func enPassantCapture() async throws {
+    var board = Board(empty: true)
+    board[0,4] = Piece(.king, .white)
+    board[7,4] = Piece(.king, .black)
+    board[4,4] = Piece(.pawn, .white)
+    board[6,3] = Piece(.pawn, .black)
+    var game = Game(board: board, currentTurn: .black)
+    try game.applyMove(from: (6,3), to: (4,3))
+    try game.applyMove(from: (4,4), to: (5,3))
+    #expect(game.board[5,3]?.color == .white)
+    #expect(game.board[4,3] == nil)
+}
+
+@Test func undoRedo() async throws {
+    var game = Game()
+    try game.applyMove(from: (1,0), to: (3,0))
+    game.undo()
+    #expect(game.board[1,0]?.type == .pawn)
+    #expect(game.board[3,0] == nil)
+    game.redo()
+    #expect(game.board[3,0]?.type == .pawn)
+}


### PR DESCRIPTION
## Summary
- add full SwiftUI board interface with Unicode pieces and tap handling
- implement move history with undo/redo
- support en passant captures
- update README features
- expand unit tests for en passant and undo/redo

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_683f4b164ac08332b767fbcf90628736